### PR TITLE
change vertsplit bg color.

### DIFF
--- a/colors/one-nvim.vim
+++ b/colors/one-nvim.vim
@@ -90,7 +90,7 @@ local highlight_groups = {
      CursorLine   = { fg = none, bg = syntax_cursor },
      Directory    = { fg = hue_2 },
      ErrorMsg     = { fg = hue_5, bg = syntax_bg },
-     VertSplit    = { fg = vertsplit, bg = vertsplit },
+     VertSplit    = { fg = vertsplit },
      Folded       = { fg = mono_3, bg = syntax_bg },
      FoldColumn   = { fg = mono_3, bg = syntax_cursor },
      IncSearch    = { fg = hue_6 },


### PR DESCRIPTION
neovim now supports continuous lines on vertchar by default.
https://github.com/neovim/neovim/pull/7986
So why not just use vertchar without changing the background color?

before
<img width="1087" alt="Screen Shot 2021-01-27 at 13 22 58" src="https://user-images.githubusercontent.com/42740055/105942579-d8035e80-60a2-11eb-9d27-5a0660cb3334.png">

after
<img width="1087" alt="Screen Shot 2021-01-27 at 13 23 21" src="https://user-images.githubusercontent.com/42740055/105942603-e2bdf380-60a2-11eb-9a3c-74d14a45db6b.png">
